### PR TITLE
Update unit tests to use explicit assertions

### DIFF
--- a/expr_tests.lgt
+++ b/expr_tests.lgt
@@ -2,26 +2,69 @@
 
 :- object(expr, extends(lgtunit)).
 
-    test(var) :- expr:eval_expr("username", ["username"-"aarroyoc"], "aarroyoc").
-    test(dict_var) :- expr:eval_expr("user.login", ["user"-["login"-"aarroyoc", "password"-"123456"]], "aarroyoc").
-    test(number) :- expr:eval_expr("42", [], "42").
-    test(string) :- expr:eval_expr("\"foo\"", [], "foo").
-    test(bool) :- expr:eval_expr("true", [], "true").
-    test(sum_2) :- expr:eval_expr("1 + 2", [], "3").
-    test(sum_3) :- expr:eval_expr("1 + 2 + 3", [], "6").
-    test(sum_minus) :- expr:eval_expr("1 + 2 - 3", [], "0").
-    test(mul) :- expr:eval_expr("1 + 3 * 3 + 1", [], "11").
-    test(mul_par) :- expr:eval_expr("(1 + 3) * 3 + 1", [], "13").
-    test(div) :- expr:eval_expr("1 - 2 / 2", [], "0").
-    test(equal) :- expr:eval_expr("1 + 2 == 3", [], "true").
-    test(not_equal) :- expr:eval_expr("3 + 1 != 2 * 2", [], "false").
-    test(and) :- expr:eval_expr("5 > 4 and 4 > 3", [], "true").
-    test(or) :- expr:eval_expr("5 >= 4 or 3 < 1", [], "true").
-    test(not) :- expr:eval_expr("not false or true", [], "false").
-    test(filter) :- expr:eval_expr("username | lower", ["username"-"AARROYOC"], "aarroyoc").
-    test(multi_filter) :- expr:eval_expr("user.login | lower | length", ["user"-["login"-"aarroyoc", "password"-"123456"]], "8").
-    test(filter_param) :- expr:eval_expr("user.login | lower | truncate(length=4)", ["user"-["login"-"aarroyoc", "password"-"123456"]], "aarr").
-    test(nth) :- expr:eval_expr("links | nth(n=1)", ["links"-["https://github.com", "https://adrianistan.eu"]], "https://adrianistan.eu").
-    test(replace) :- expr:eval_expr("username | replace(from=\"yo\", to=\"pu\")", ["username"-"aarroyoc"], "aarropuc").
+    :- use_module(expr, [eval_expr/3]).
+
+    test(var, true(Result == "aarroyoc")) :-
+        eval_expr("username", ["username"-"aarroyoc"], Result).
+
+    test(dict_var, true(Result == "aarroyoc")) :-
+        eval_expr("user.login", ["user"-["login"-"aarroyoc", "password"-"123456"]], Result).
+
+    test(number, true(Result == "42")) :-
+        eval_expr("42", [], Result).
+
+    test(string, true(Result == "foo")) :-
+        eval_expr("\"foo\"", [], Result).
+
+    test(bool, true(Result == "true")) :-
+        eval_expr("true", [], Result).
+
+    test(sum_2, true(Result == "3")) :-
+        eval_expr("1 + 2", [], Result).
+
+    test(sum_3, true(Result == "6")) :-
+        eval_expr("1 + 2 + 3", [], Result).
+
+    test(sum_minus, true(Result == "0")) :-
+        eval_expr("1 + 2 - 3", [], Result).
+
+    test(mul, true(Result == "11")) :-
+        eval_expr("1 + 3 * 3 + 1", [], Result).
+
+    test(mul_par, true(Result == "13")) :-
+        eval_expr("(1 + 3) * 3 + 1", [], Result).
+
+    test(div, true(Result == "0")) :-
+        eval_expr("1 - 2 / 2", [], Result).
+
+    test(equal, true(Result == "true")) :-
+        eval_expr("1 + 2 == 3", [], Result).
+
+    test(not_equal, true(Result == "false")) :-
+        eval_expr("3 + 1 != 2 * 2", [], Result).
+
+    test(and, true(Result == "true")) :-
+        eval_expr("5 > 4 and 4 > 3", [], Result).
+
+    test(or, true(Result == "true")) :-
+        eval_expr("5 >= 4 or 3 < 1", [], Result).
+
+    test(not, true(Result == "false")) :-
+        eval_expr("not false or true", [], Result).
+
+    test(filter, true(Result == "aarroyoc")) :-
+        eval_expr("username | lower", ["username"-"AARROYOC"], Result).
+
+    test(multi_filter, true(Result == "8")) :-
+        eval_expr("user.login | lower | length", ["user"-["login"-"aarroyoc", "password"-"123456"]], Result).
+
+    test(filter_param, true(Result == "aarr")) :-
+        eval_expr("user.login | lower | truncate(length=4)", ["user"-["login"-"aarroyoc", "password"-"123456"]], Result).
+
+    test(nth, true(Result == "https://adrianistan.eu")) :-
+        eval_expr("links | nth(n=1)", ["links"-["https://github.com", "https://adrianistan.eu"]], Result).
+
+    test(replace, true(Result == "aarropuc")) :-
+        eval_expr("username | replace(from=\"yo\", to=\"pu\")", ["username"-"aarroyoc"], Result).
 
 :- end_object.

--- a/filters_tests.lgt
+++ b/filters_tests.lgt
@@ -2,24 +2,61 @@
 
 :- object(filters, extends(lgtunit)).
 
-    test(lower) :- filters:filter_lower("AbC", "abc").
-    test(upper) :- filters:filter_upper("aBc", "ABC").
-    test(length) :- filters:filter_length("abc  ", "5").
-    test(wordcount) :- filters:filter_wordcount("  hola  amigos de   Perú", "4").
-    test(capitalize) :- filters:filter_capitalize("abc", "Abc").
-    test(trim) :- filters:filter_trim("     hola amigos  ", "hola amigos").
-    test(trim_start) :- filters:filter_trim_start("     hola amigos  ", "hola amigos  ").
-    test(trim_end) :- filters:filter_trim_end("     hola amigos  ", "     hola amigos").
-    test(truncate) :- filters:filter_truncate("hola amigos", "hola", ["length"-number("4")]).
-    test(first) :- filters:filter_first([1,2,3], 1).
-    test(last) :- filters:filter_last([1,2,3], 3).
-    test(nth) :- filters:filter_nth([1,2,3], 2, ["n"-number("1")]).
-    test(replace) :- filters:filter_replace("hola amigos", "adios amigos", ["from"-string("hola"), "to"-string("adios")]).
-    test(title) :- filters:filter_title("hola amigos  cruel", "Hola Amigos Cruel").
-    test(join) :- filters:filter_join(["hola", "amigos", "cruel"], "hola//amigos//cruel", ["sep"-string("//")]).
-    test(reverse) :- filters:filter_reverse("hola amigos", "sogima aloh").
-    test(simple_sort) :- filters:filter_sort([4,2,1,3], [1,2,3,4]).
-    test(complex_sort) :- filters:filter_sort([["age"-34, "name"-"Pepe"], ["age"-21, "name"-"Marisa"], ["age"-56, "name"-"César"]], [["age"-21, "name"-"Marisa"], ["age"-34, "name"-"Pepe"], ["age"-56, "name"-"César"]], ["key"-string("age")]).
-    test(unique) :- filters:filter_unique([1,2,3,1,2,3], [1,2,3]).
+    test(lower, true(Result == "abc")) :-
+        filters:filter_lower("AbC", Result).
+
+    test(upper, true(Result == "ABC")) :-
+        filters:filter_upper("aBc", Result).
+
+    test(length, true(Result == "5")) :-
+        filters:filter_length("abc  ", Result).
+
+    test(wordcount, true(Result == "4")) :-
+        filters:filter_wordcount("  hola  amigos de   Perú", Result).
+
+    test(capitalize, true(Result == "Abc")) :-
+        filters:filter_capitalize("abc", Result).
+
+    test(trim, true(Result == "hola amigos")) :-
+        filters:filter_trim("     hola amigos  ", Result).
+
+    test(trim_start, true(Result == "hola amigos  ")) :-
+        filters:filter_trim_start("     hola amigos  ", Result).
+
+    test(trim_end, true(Result == "     hola amigos")) :-
+        filters:filter_trim_end("     hola amigos  ", Result).
+
+    test(truncate, true(Result == "hola")) :-
+        filters:filter_truncate("hola amigos", Result, ["length"-number("4")]).
+
+    test(first, true(Result == 1)) :-
+        filters:filter_first([1,2,3], Result).
+
+    test(last, true(Result == 3)) :-
+        filters:filter_last([1,2,3], Result).
+
+    test(nth, true(Result == 2)) :-
+        filters:filter_nth([1,2,3], Result, ["n"-number("1")]).
+
+    test(replace, true(Result == "adios amigos")) :-
+        filters:filter_replace("hola amigos", Result, ["from"-string("hola"), "to"-string("adios")]).
+
+    test(title, true(Result == "Hola Amigos Cruel")) :-
+        filters:filter_title("hola amigos  cruel", Result).
+
+    test(join, true(Result == "hola//amigos//cruel")) :-
+        filters:filter_join(["hola", "amigos", "cruel"], Result, ["sep"-string("//")]).
+
+    test(reverse, true(Result == "sogima aloh")) :-
+        filters:filter_reverse("hola amigos", Result).
+
+    test(simple_sort, true(Result == [1,2,3,4])) :-
+        filters:filter_sort([4,2,1,3], Result).
+
+    test(complex_sort, true(Result == [["age"-21, "name"-"Marisa"], ["age"-34, "name"-"Pepe"], ["age"-56, "name"-"César"]])) :-
+        filters:filter_sort([["age"-34, "name"-"Pepe"], ["age"-21, "name"-"Marisa"], ["age"-56, "name"-"César"]], Result, ["key"-string("age")]).
+
+    test(unique, true(Result == [1,2,3])) :-
+        filters:filter_unique([1,2,3,1,2,3], Result).
 
 :- end_object.

--- a/tests.lgt
+++ b/tests.lgt
@@ -2,26 +2,28 @@
 
 :- object(tests, extends(lgtunit)).
 
-    test(trivial) :- true.
+    test(trivial, true) :-
+        true.
 
-    test(simple_substitution) :- template_test("templates/a.in.html", "templates/a.out.html", ["username"-"aarroyoc"]).
-    test(raw_block) :- template_test("templates/b.in.html", "templates/b.out.html", ["username"-"aarroyoc"]).
-    test(comment_block) :- template_test("templates/c.in.html", "templates/c.out.html", ["username"-"aarroyoc"]).
+    test(simple_substitution, true(Assertion)) :-
+        template_test("templates/a.in.html", "templates/a.out.html", ["username"-"aarroyoc"], Assertion).
 
-    test(for_loop) :- template_test("templates/h.in.html", "templates/h.out.html", ["username"-"aarroyoc", "links"-["https://github.com", "https://adrianistan.eu"]]).
-    test(for_loop_filter) :- template_test("templates/j.in.html", "templates/j.out.html", ["webs"-[["name"-"Google", "popularity"-100], ["name"-"GitHub", "popularity"-40]]]).
+    test(raw_block, true(Assertion)) :-
+        template_test("templates/b.in.html", "templates/b.out.html", ["username"-"aarroyoc"], Assertion).
 
-    template_test(In, Out, Vars) :-
+    test(comment_block, true(Assertion)) :-
+        template_test("templates/c.in.html", "templates/c.out.html", ["username"-"aarroyoc"], Assertion).
+
+    test(for_loop, true(Assertion)) :-
+        template_test("templates/h.in.html", "templates/h.out.html", ["username"-"aarroyoc", "links"-["https://github.com", "https://adrianistan.eu"]], Assertion).
+
+    test(for_loop_filter, true(Assertion)) :-
+        template_test("templates/j.in.html", "templates/j.out.html", ["webs"-[["name"-"Google", "popularity"-100], ["name"-"GitHub", "popularity"-40]]], Assertion).
+
+    % auxiliary predicates
+
+    template_test(In, Out, Vars, Assertion) :-
       teruel:render(In, Vars, OutputReal),
-      open(Out, read, Stream),
-      read_string(Stream, OutputExpected),
-      OutputReal = OutputExpected.
-
-    read_string(Stream, String) :-
-        get_char(Stream, C),
-        ( C = end_of_file ->
-          String = []
-        ; (read_string(Stream, S0), String = [C|S0])
-        ).
+      ^^text_file_assertion(Out, OutputReal, Assertion).
 
 :- end_object.


### PR DESCRIPTION
With these changes, there's a single test that now fails:

```text
!     div: failure (in 0.0 seconds)
!       test assertion failed: "0.0"=="0"
!       in file /Users/pmoura/Documents/Prolog/teruel/expr_tests.lgt between lines 35-38
```

The failure seems to be caused by a bug either in the implementation of the `expr:eval_expr/3` predicate or (less likely) a bug in Scryer Prolog, which I used to run the tests.